### PR TITLE
stack22 ruby 対応

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -7,4 +7,14 @@ BIN_DIR=$(cd $(dirname $0); pwd)
 
 source "$BIN_DIR/support/functions"
 
-ruby $BIN_DIR/support/merge_yaml $BUILD_DIR/tmp/heroku-buildpack-release-step.yml $BUILD_DIR/tmp/buildpack-review-apps-aws-rds-release-step.yml
+SCRIPT=$BIN_DIR/support/merge_yaml
+MAIN_YML=$BUILD_DIR/tmp/heroku-buildpack-release-step.yml
+RDS_YML=$BUILD_DIR/tmp/buildpack-review-apps-aws-rds-release-step.yml
+
+if [ "$HEROKU_STACK" = "heroku-20" ]; then
+    ruby $SCRIPT $MAIN_YML $RDS_YML
+elif [ "$HEROKU_STACK" = "heroku-22" ]; then
+    bin/ruby $SCRIPT $MAIN_YML $RDS_YML
+else
+    echo "Unknown Heroku stack: $HEROKU_STACK"
+fi


### PR DESCRIPTION
### 概要

- Ruby 3.2 系のプロジェクトは Heroku Stack 22 が使われる
- Ruby がシステムインストールされてないため yml をマージする段階でエラーが出る
  - https://devcenter.heroku.com/ja/articles/heroku-22-stack
- heroku/ruby ビルドパックを入れてあると Ruby を使うことができるのだが、パスが変わっているため修正
